### PR TITLE
Use rules_webtesting in closure_js_test

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -131,3 +131,41 @@ java_import_external(
     testonly_ = 1,
     deps = ["@com_google_guava"],
 )
+
+http_archive(
+    name = "io_bazel_rules_webtesting",
+    sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
+    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz"],
+)
+
+load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
+load("@io_bazel_rules_webtesting//web:java_repositories.bzl", "java_repositories")
+
+web_test_repositories()
+
+browser_repositories(
+    chromium = True,
+    firefox = True,
+)
+
+java_repositories()
+
+java_import_external(
+    name = "org_seleniumhq_selenium_selenium_support",
+    jar_sha256 = "2c74196d15277ce6003454d72fc3434091dbf3ba65060942719ba551509404d8",
+    jar_urls = [
+        "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-support/3.141.59/selenium-support-3.141.59.jar",
+    ],
+    licenses = ["notice"],  # The Apache Software License, Version 2.0
+    testonly_ = 1,
+    deps = [
+        "@com_google_guava_guava",
+        "@net_bytebuddy_byte_buddy",
+        "@com_squareup_okhttp3_okhttp",
+        "@com_squareup_okio_okio",
+        "@org_apache_commons_commons_exec",
+        "@org_seleniumhq_selenium_selenium_api",
+        "@org_seleniumhq_selenium_selenium_remote_driver",
+    ],
+)

--- a/closure/testing/BUILD
+++ b/closure/testing/BUILD
@@ -22,6 +22,7 @@ licenses(["notice"])  # Apache 2.0
 load("//closure:defs.bzl", "closure_js_binary", "closure_js_library")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+# html place holder used by PhantomJS.
 exports_files(["empty.html"])
 
 closure_js_library(
@@ -60,3 +61,23 @@ bzl_library(
     ],
 )
 
+# html template used by webtest runner.
+exports_files(["LICENSE", "gen_webtest_html.template"])
+
+java_library(
+    name = "testrunner_lib",
+    testonly = 1,
+    srcs = [
+        "WebtestDriver.java",
+        "WebtestRunner.java",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_seleniumhq_selenium_selenium_api",
+        "@org_seleniumhq_selenium_selenium_support",
+        "@org_seleniumhq_selenium_selenium_remote_driver",
+        "@io_bazel_rules_webtesting//java/com/google/testing/web:web",
+        "//java/io/bazel/rules/closure/webfiles/server",
+        "@com_google_guava",
+    ],
+)

--- a/closure/testing/WebtestDriver.java
+++ b/closure/testing/WebtestDriver.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Closure Rules Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rules_closure.closure.testing;
+
+import com.google.testing.web.WebTest;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.openqa.selenium.net.PortProber;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.WebDriver;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class WebtestDriver {
+
+  private static final Logger logger = Logger.getLogger(WebtestDriver.class.getName());
+
+  private WebDriver driver;
+  private String runURL;
+
+  public WebtestDriver(String runURL) {
+    this.driver = new WebTest().newWebDriverSession();
+    this.runURL = runURL;
+  }
+
+  public void run() {
+    driver.manage().timeouts().setScriptTimeout(60, SECONDS);
+    logger.info("RunURL is: " + this.runURL);
+    driver.get(this.runURL);
+
+    new FluentWait<>((JavascriptExecutor) driver)
+        .pollingEvery(Duration.ofMillis(100))
+        .withTimeout(Duration.ofSeconds(5))
+        .until(executor -> {
+          boolean finishedSuccessfully = (boolean) executor.executeScript("return window.top.G_testRunner.isFinished()");
+          if (!finishedSuccessfully) {
+            logger.log(Level.SEVERE, "G_testRunner has not finished successfully");
+          }
+          return true;
+        }
+    );
+
+    String testReport = ((JavascriptExecutor) driver).executeScript("return window.top.G_testRunner.getReport();").toString();
+    logger.info(testReport);
+
+    boolean allTestsPassed = (boolean) ((JavascriptExecutor) driver).executeScript("return window.top.G_testRunner.isSuccess();");
+
+    driver.quit();
+
+    if (!allTestsPassed) {
+      logger.log(Level.SEVERE, "Test failed");
+    }
+  }
+}

--- a/closure/testing/WebtestRunner.java
+++ b/closure/testing/WebtestRunner.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 The Closure Rules Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rules_closure.closure.testing;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.HostAndPort;
+import io.bazel.rules.closure.webfiles.server.DaggerWebfilesServer_Server;
+import io.bazel.rules.closure.webfiles.server.WebfilesServer;
+import java.nio.file.FileSystems;
+import java.io.IOException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import javax.net.ServerSocketFactory;
+import rules_closure.closure.testing.WebtestDriver;
+
+class WebtestRunner {
+  /*
+   *  This program starts an HTTP server that serves runfiles.
+   *  It uses a webdriver to load the generated test runner HTML file
+   *  on the browser. Once the page is loaded, it polls the Closure
+   *  Library repeatedly to check if the tests are finished, and logs results.
+   */
+
+  public static void main(String args[]) throws InterruptedException {
+
+    String serverConfig = System.getProperty("server_config_path");
+    String htmlWebpath = System.getProperty("html_webpath");
+
+    ExecutorService serverExecutor = Executors.newCachedThreadPool();
+    WebfilesServer server =
+        DaggerWebfilesServer_Server.builder()
+            .args(ImmutableList.of(serverConfig))
+            .executor(serverExecutor)
+            .fs(FileSystems.getDefault())
+            .serverSocketFactory(ServerSocketFactory.getDefault())
+            .build()
+            .server();
+
+    HostAndPort hostAndPort = server.spawn();
+    String address = hostAndPort.toString();
+
+    String runURL = "http://" + address + htmlWebpath;
+    WebtestDriver driver = new WebtestDriver(runURL);
+    driver.run();
+
+    // TODO: Find out how to shutdown the server
+    serverExecutor.shutdownNow();
+    System.exit(0);
+  }
+}

--- a/closure/testing/closure_js_test.bzl
+++ b/closure/testing/closure_js_test.bzl
@@ -17,6 +17,8 @@
 load("//closure/compiler:closure_js_binary.bzl", "closure_js_binary")
 load("//closure/compiler:closure_js_library.bzl", "closure_js_library")
 load("//closure/testing:phantomjs_test.bzl", "phantomjs_test")
+load("//closure:webfiles/web_library.bzl", "web_library", "get_web_library_config")
+load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
 
 def closure_js_test(
         name,
@@ -34,6 +36,7 @@ def closure_js_test(
         visibility = None,
         tags = [],
         debug = False,
+        browsers = None,
         **kwargs):
     if not srcs:
         fail("closure_js_test rules can not have an empty 'srcs' list")
@@ -47,6 +50,7 @@ def closure_js_test(
     else:
         work = [(name + _make_suffix(src), [src]) for src in srcs]
     for shard, sauce in work:
+
         closure_js_library(
             name = "%s_lib" % shard,
             srcs = sauce,
@@ -78,16 +82,68 @@ def closure_js_test(
             tags = tags,
         )
 
-        phantomjs_test(
-            name = shard,
-            runner = str(Label("//closure/testing:phantomjs_jsunit_runner")),
-            deps = [":%s_bin" % shard],
-            debug = debug,
-            html = html,
-            visibility = visibility,
-            tags = tags,
-            **kwargs
-        )
+        if not browsers:
+            phantomjs_test(
+                name = shard,
+                runner = str(Label("//closure/testing:phantomjs_jsunit_runner")),
+                deps = [":%s_bin" % shard],
+                debug = debug,
+                html = html,
+                visibility = visibility,
+                tags = tags,
+                **kwargs
+            )
+
+        else:
+            html = "gen_html_%s" % shard
+            gen_test_html(
+                name = html,
+                test_file_js = "%s_bin.js" % shard,
+            )
+
+            host = "localhost"
+            port = "8080"
+            path = "/"
+            html_webpath = "%s%s.html" % (path, html)
+
+            web_library(
+                name = "%s_debug" % shard,
+                srcs = [html, "%s_bin" % shard],
+                port = port,
+                host = host,
+                path = path,
+            )
+
+            web_config = "%s_server_config" % shard
+            get_web_library_config(
+                name = web_config,
+                srcs = [html, "%s_bin" % shard],
+                port = port,
+                host = host,
+                path = path,
+            )
+
+            native.java_binary(
+                name = "%s_testrunner" % shard,
+                data = [":%s_bin" % shard, html, web_config],
+                main_class = "rules_closure.closure.testing.WebtestRunner",
+                jvm_flags = [
+                    "-Dserver_config_path=$(location :%s)" % web_config,
+                    "-Dhtml_webpath=%s" % html_webpath,
+                ],
+                runtime_deps = [str(Label("//closure/testing:testrunner_lib"))],
+                testonly = 1,
+            )
+
+            web_test_suite(
+                name = shard,
+                data = [":%s_bin" % shard, html, web_config],
+                test = ":%s_testrunner" % shard,
+                browsers = browsers,
+                tags = ["no-sandbox", "native"],
+                visibility = visibility,
+                **kwargs
+            )
 
     if len(srcs) > 1:
         native.test_suite(
@@ -98,3 +154,31 @@ def closure_js_test(
 
 def _make_suffix(path):
     return "_" + path.replace("_test.js", "").replace("-", "_").replace("/", "_")
+
+def _gen_test_html_impl(ctx):
+    """Implementation of the gen_test_html rule."""
+    ctx.actions.expand_template(
+        template = ctx.file._template,
+        output = ctx.outputs.html_file,
+        substitutions = {
+            "{{TEST_FILE_JS}}": ctx.attr.test_file_js,
+        },
+    )
+    runfiles = ctx.runfiles(files = [ctx.outputs.html_file], collect_default = True)
+    return [DefaultInfo(runfiles = runfiles)]
+
+# Used to generate default test.html file for running Closure-based JS tests.
+# The test_file_js argument specifies the name of the JS file containing tests,
+# typically created with closure_js_binary.
+# The output is created from gen_test_html.template file.
+gen_test_html = rule(
+    implementation = _gen_test_html_impl,
+    attrs = {
+        "test_file_js": attr.string(mandatory = True),
+        "_template": attr.label(
+            default = Label("//closure/testing:gen_webtest_html.template"),
+            allow_single_file = True,
+        ),
+    },
+    outputs = {"html_file": "%{name}.html"},
+)

--- a/closure/testing/gen_webtest_html.template
+++ b/closure/testing/gen_webtest_html.template
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+<!--
+Copyright 2022 The Closure Rules Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+</head>
+<body>
+<!--
+This is a template of the default test file used for running JS tests
+declared with closure_js_test rules.
+-->
+<script>
+  // goog.require does not need to fetch sources from the local
+  // server because everything is compiled and loaded explicitly below.
+  var CLOSURE_NO_DEPS = true;
+  var CLOSURE_UNCOMPILED_DEFINES = {};
+</script>
+<script src="{{TEST_FILE_JS}}"></script>
+</body>
+</html>

--- a/closure/testing/test/BUILD
+++ b/closure/testing/test/BUILD
@@ -32,6 +32,7 @@ closure_js_test(
         "@com_google_javascript_closure_library//closure/goog/testing:asserts",
         "@com_google_javascript_closure_library//closure/goog/testing:jsunit",
     ],
+    browsers = ["@io_bazel_rules_webtesting//browsers:chromium-local"],
 )
 
 closure_js_library(
@@ -50,6 +51,7 @@ closure_js_test(
         "@com_google_javascript_closure_library//closure/goog/testing:jsunit",
         "@com_google_javascript_closure_library//closure/goog/testing:testsuite",
     ],
+    browsers = ["@io_bazel_rules_webtesting//browsers:chromium-local"],
 )
 
 closure_js_test(
@@ -62,6 +64,7 @@ closure_js_test(
         "@com_google_javascript_closure_library//closure/goog/testing:jsunit",
         "@com_google_javascript_closure_library//closure/goog/testing:testsuite",
     ],
+    browsers = ["@io_bazel_rules_webtesting//browsers:chromium-local"],
 )
 
 closure_js_library(
@@ -80,6 +83,7 @@ closure_js_test(
         "@com_google_javascript_closure_library//closure/goog/testing:asserts",
         "@com_google_javascript_closure_library//closure/goog/testing:jsunit",
     ],
+    browsers = ["@io_bazel_rules_webtesting//browsers:chromium-local"],
 )
 
 # Note that this is also validating Closure Library integration.
@@ -94,6 +98,7 @@ closure_js_test(
         "@com_google_javascript_closure_library//closure/goog/testing:asserts",
         "@com_google_javascript_closure_library//closure/goog/testing:jsunit",
     ],
+    browsers = ["@io_bazel_rules_webtesting//browsers:chromium-local"],
 )
 
 closure_js_library(
@@ -112,6 +117,7 @@ closure_js_test(
         "@com_google_javascript_closure_library//closure/goog/testing:asserts",
         "@com_google_javascript_closure_library//closure/goog/testing:testsuite",
     ],
+    browsers = ["@io_bazel_rules_webtesting//browsers:chromium-local"],
 )
 
 closure_js_test(
@@ -123,6 +129,7 @@ closure_js_test(
     deps = [
         "@com_google_javascript_closure_library//closure/goog/testing:testsuite",
     ],
+    browsers = ["@io_bazel_rules_webtesting//browsers:chromium-local"],
 )
 
 # This test shows how to write tests to verify rendered output from phantomjs.

--- a/closure/webfiles/web_library.bzl
+++ b/closure/webfiles/web_library.bzl
@@ -23,69 +23,22 @@ load(
 )
 
 def _web_library(ctx):
-    if not ctx.attr.srcs:
-        if ctx.attr.deps:
-            fail("deps can not be set when srcs is not")
-        if not ctx.attr.exports:
-            fail("exports must be set if srcs is not")
-    if ctx.attr.path:
-        if not ctx.attr.path.startswith("/"):
-            fail("webpath must start with /")
-        if ctx.attr.path != "/" and ctx.attr.path.endswith("/"):
-            fail("webpath must not end with / unless it is /")
-        if "//" in ctx.attr.path:
-            fail("webpath must not have //")
-    elif ctx.attr.srcs:
-        fail("path must be set when srcs is set")
-    if "*" in ctx.attr.suppress and len(ctx.attr.suppress) != 1:
-        fail("when \"*\" is suppressed no other items should be present")
+    (webpaths, manifest, manifests, params_file) = _web_library_common(ctx)
 
-    # process what came before
-    deps = unfurl(ctx.attr.deps, provider = "webfiles")
-    webpaths = []
-    manifests = []
-    for dep in deps:
-        webpaths.append(dep.webfiles.webpaths)
-        manifests += [dep.webfiles.manifests]
-
-    # process what comes now
-    new_webpaths = []
-    manifest_srcs = []
-    path = ctx.attr.path
-    strip = _get_strip(ctx)
-    for src in ctx.files.srcs:
-        suffix = _get_path_relative_to_package(src)
-        if strip:
-            if not suffix.startswith(strip):
-                fail("Relative src path not start with '%s': %s" % (strip, suffix))
-            suffix = suffix[len(strip):]
-        webpath = "%s/%s" % ("" if path == "/" else path, suffix)
-        if webpath in new_webpaths:
-            _fail(ctx, "multiple srcs within %s define the webpath %s " % (
-                ctx.label,
-                webpath,
-            ))
-        if webpath in webpaths:
-            _fail(ctx, "webpath %s was defined by %s when already defined by deps" % (
-                webpath,
-                ctx.label,
-            ))
-        new_webpaths.append(webpath)
-        manifest_srcs.append(struct(
-            path = src.path,
-            longpath = long_path(ctx, src),
-            webpath = webpath,
-        ))
-    webpaths += [depset(new_webpaths)]
-    manifest = ctx.actions.declare_file("%s.pbtxt" % ctx.label.name)
     ctx.actions.write(
-        output = manifest,
-        content = struct(
-            label = str(ctx.label),
-            src = manifest_srcs,
-        ).to_proto(),
+        is_executable = True,
+        output = ctx.outputs.executable,
+        content = "#!/bin/sh\nexec %s %s \"$@\"" % (
+            ctx.executable._WebfilesServer.short_path,
+            params_file.short_path,
+        ),
     )
-    manifests = depset([manifest], transitive = manifests, order = "postorder")
+
+    deps = unfurl(ctx.attr.deps, provider = "webfiles")
+    transitive_runfiles = depset(
+        transitive = [ctx.attr._WebfilesServer.data_runfiles.files] +
+                     [dep.data_runfiles.files for dep in deps],
+    )
 
     # perform strict dependency checking
     inputs = [manifest]
@@ -123,32 +76,6 @@ def _web_library(ctx):
         mnemonic = "Closure",
         execution_requirements = {"supports-workers": "1"},
         progress_message = "Checking webfiles in %s" % ctx.label,
-    )
-
-    # define development web server that only applies to this transitive closure
-    params = struct(
-        label = str(ctx.label),
-        bind = "%s:%s" % (str(ctx.attr.host), str(ctx.attr.port)),
-        manifest = [long_path(ctx, man) for man in manifests.to_list()],
-        external_asset = [
-            struct(webpath = k, path = v)
-            for k, v in ctx.attr.external_assets.items()
-        ],
-    )
-    params_file = ctx.actions.declare_file("%s_server_params.pbtxt" % ctx.label.name)
-    ctx.actions.write(output = params_file, content = params.to_proto())
-    ctx.actions.write(
-        is_executable = True,
-        output = ctx.outputs.executable,
-        content = "#!/bin/sh\nexec %s %s \"$@\"" % (
-            ctx.executable._WebfilesServer.short_path,
-            long_path(ctx, params_file),
-        ),
-    )
-
-    transitive_runfiles = depset(
-        transitive = [ctx.attr._WebfilesServer.data_runfiles.files] +
-                     [dep.data_runfiles.files for dep in deps],
     )
 
     return struct(
@@ -204,6 +131,91 @@ def _get_strip(ctx):
             strip += "/"
     return strip
 
+def _verify_attributes(ctx):
+    if not ctx.attr.srcs:
+        if ctx.attr.deps:
+            fail("deps can not be set when srcs is not")
+        if not ctx.attr.exports:
+            fail("exports must be set if srcs is not")
+    if ctx.attr.path:
+        if not ctx.attr.path.startswith("/"):
+            fail("webpath must start with /")
+        if ctx.attr.path != "/" and ctx.attr.path.endswith("/"):
+            fail("webpath must not end with / unless it is /")
+        if "//" in ctx.attr.path:
+            fail("webpath must not have //")
+    elif ctx.attr.srcs:
+        fail("path must be set when srcs is set")
+    if "*" in ctx.attr.suppress and len(ctx.attr.suppress) != 1:
+        fail("when \"*\" is suppressed no other items should be present")
+
+
+def _web_library_common(ctx):
+    _verify_attributes(ctx)
+
+    # process what came before
+    deps = unfurl(ctx.attr.deps, provider = "webfiles")
+    webpaths = []
+    manifests = []
+    for dep in deps:
+        webpaths.append(dep.webfiles.webpaths)
+        manifests += [dep.webfiles.manifests]
+
+    # process what comes now
+    new_webpaths = []
+    manifest_srcs = []
+    path = ctx.attr.path
+    strip = _get_strip(ctx)
+    for src in ctx.files.srcs:
+        suffix = _get_path_relative_to_package(src)
+        if strip:
+            if not suffix.startswith(strip):
+                fail("Relative src path not start with '%s': %s" % (strip, suffix))
+            suffix = suffix[len(strip):]
+        webpath = "%s/%s" % ("" if path == "/" else path, suffix)
+        if webpath in new_webpaths:
+            _fail(ctx, "multiple srcs within %s define the webpath %s " % (
+                ctx.label,
+                webpath,
+            ))
+        if webpath in webpaths:
+            _fail(ctx, "webpath %s was defined by %s when already defined by deps" % (
+                webpath,
+                ctx.label,
+            ))
+        new_webpaths.append(webpath)
+        manifest_srcs.append(struct(
+            path = src.path,
+            longpath = long_path(ctx, src),
+            webpath = webpath,
+        ))
+    webpaths += [depset(new_webpaths)]
+    manifest = ctx.actions.declare_file("%s.pbtxt" % ctx.label.name)
+    ctx.actions.write(
+        output = manifest,
+        content = struct(
+            label = str(ctx.label),
+            src = manifest_srcs,
+        ).to_proto(),
+    )
+    manifests = depset([manifest], transitive = manifests, order = "postorder")
+
+    # define development web server that only applies to this transitive closure
+    params = struct(
+        label = str(ctx.label),
+        bind = "%s:%s" % (str(ctx.attr.host), str(ctx.attr.port)),
+        manifest = [long_path(ctx, man) for man in manifests.to_list()],
+        external_asset = [
+            struct(webpath = k, path = v)
+            for k, v in ctx.attr.external_assets.items()
+        ],
+    )
+    params_file = ctx.actions.declare_file("%s_server_params.pbtxt" % ctx.label.name)
+    ctx.actions.write(output = params_file, content = params.to_proto())
+
+    return (webpaths, manifest, manifests, params_file)
+
+
 web_library = rule(
     implementation = _web_library,
     executable = True,
@@ -235,3 +247,30 @@ web_library = rule(
         "dummy": "%{name}.ignoreme",
     },
 )
+
+def _get_web_library_config_impl(ctx):
+    (webpaths, manifest, manifests, params_file) = _web_library_common(ctx)
+
+    runfiles = ctx.runfiles(
+    files = [ctx.outputs.config_file, manifest], collect_default = True)
+    return [DefaultInfo(runfiles = runfiles)]
+
+get_web_library_config = rule(
+    implementation = _get_web_library_config_impl,
+    attrs = {
+        "path": attr.string(),
+        "host": attr.string(default = "0.0.0.0"),
+        "port": attr.string(default = "6006"),
+        "srcs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(providers = ["webfiles"]),
+        "exports": attr.label_list(),
+        "data": attr.label_list(allow_files = True),
+        "suppress": attr.string_list(),
+        "strip_prefix": attr.string(),
+        "external_assets": attr.string_dict(default = {"/_/runfiles": "."}),
+    },
+    outputs = {
+        "config_file": "%{name}_server_params.pbtxt",
+    },
+)
+

--- a/java/io/bazel/rules/closure/webfiles/server/Metadata.java
+++ b/java/io/bazel/rules/closure/webfiles/server/Metadata.java
@@ -89,9 +89,9 @@ final class Metadata {
     private final String args;
 
     @Inject
-    Config(Runfiles runfiles, @Args ImmutableList<String> args) {
+    Config(FileSystem fs, @Args ImmutableList<String> args) {
       Iterator<String> i = args.iterator();
-      this.path = runfiles.getPath(i.next());
+      this.path = fs.getPath(i.next());
       this.args = Joiner.on(' ').join(i);
     }
 

--- a/java/io/bazel/rules/closure/webfiles/server/WebfilesServer.java
+++ b/java/io/bazel/rules/closure/webfiles/server/WebfilesServer.java
@@ -192,7 +192,7 @@ public final class WebfilesServer implements Runnable {
 
   @ServerScope
   @Component
-  interface Server
+  public interface Server
       extends HttpServerComponent<
           Transmitter<Processor>, Connection, Connection.Builder, Request, Request.Builder> {
     WebfilesServer server();


### PR DESCRIPTION
# Overview
Introduce a new attribute `browsers` to the existing `closure_js_test` macro.
* If `browsers` is specified, the tests will be run with rules_webtesting / Selenium webdriver.
* If `browsers` is not specified, there are no changes to the existing operation - the tests are run on phantomjs.

Example:
```
closure_js_test(
    name = "simple_test",
    timeout = "short",
    srcs = ["simple_test.js"],
    deps = [
        "@com_google_javascript_closure_library//closure/goog/testing:asserts",
        "@com_google_javascript_closure_library//closure/goog/testing:jsunit",
    ],
    browsers = ["@io_bazel_rules_webtesting//browsers:chromium-local"],
)
```
I updated the tests in [rules_closure/closure/testing/test/](https://github.com/bazelbuild/rules_closure/tree/master/closure/testing/test) to run with this feature.

# Test runner details

A  test runner is added to run the tests with rules_webtesting. Here's what it does
* generates an .html file that acts as an entry point to call the tests.
* runs a [WebfilesServer](https://github.com/bazelbuild/rules_closure/blob/master/java/io/bazel/rules/closure/webfiles/server/WebfilesServer.java) that serves the js test binary and html file. (*)
* creates a webdriver session to start running the tests. When the tests are running, it repeatedly polls the Closure library to see if the tests have finished.
* finally, it collects and logs the test results.

### (*) A few changes made to the WebfilesServer:
* The server takes 1 argument - a relative path to the config file to start running. Previously, it looked up the config file by going up one directory layer (e.g: `../workspace_name/path/to/config/file`), and then the arg needs to be a [long path](https://github.com/bazelbuild/rules_closure/blob/master/closure/private/defs.bzl#L246-L252) (e.g: `workspace_name/path/to/config/file`) to point to the correct location. In the closure_js_test marcro, it is currently not possible to get the long path to start the server, so I changed the server to look up `/path/to/config/file` directly.
* I also reused some code in [web_library.bzl](https://github.com/bazelbuild/rules_closure/blob/master/closure/webfiles/web_library.bzl) to generate the config file to start the server. Please advise if I should refactor/modify this file better.
