### PR TITLE
Shutdown driver and server resources properly

### DIFF
--- a/java/io/bazel/rules/closure/webfiles/server/WebfilesServer.java
+++ b/java/io/bazel/rules/closure/webfiles/server/WebfilesServer.java
@@ -124,13 +124,8 @@ public final class WebfilesServer implements Runnable {
 
   /** Shuts down the server. */
   public void shutdown() {
-    synchronized (this) {
-      if (executor instanceof ExecutorService) {
-        ((ExecutorService) executor).shutdownNow();
-        System.exit(0);
-      } else {
-        logger.log(Level.SEVERE, "Cannot shutdown server");
-      }
+    if (executor instanceof ExecutorService) {
+      ((ExecutorService) executor).shutdownNow();
     }
   }
 


### PR DESCRIPTION
- Simplify WebfilesServer's shutdown method
- Move webdriver quit() action from TestDriver to TestRunner